### PR TITLE
Make the Elastic IP association depend on the NSvInstance.

### DIFF
--- a/single-ami/cf-existing-vpc.template
+++ b/single-ami/cf-existing-vpc.template
@@ -215,6 +215,7 @@
                     "Ref": "NSvInstanceInterfaceWan"
                 }
             },
+            "DependsOn": "NSvInstance",
             "Type": "AWS::EC2::EIPAssociation"
         },
         "NSvInstance": {


### PR DESCRIPTION
This is to avoid a resource handler error: "The pending-instance-creation instance to which 'eni-xxxx' is attached is not in a valid state for this operation."